### PR TITLE
Refactor to allow for multiple parsers

### DIFF
--- a/src/c4parser.rs
+++ b/src/c4parser.rs
@@ -1,0 +1,60 @@
+use headless_chrome::{Browser, LaunchOptionsBuilder};
+use log;
+use scraper::{Html, Selector};
+use url::Url;
+
+use crate::html_parsing::{WebsiteParser, Repo};
+
+
+pub struct Code4renaParser;
+
+impl WebsiteParser for Code4renaParser {
+    fn parse_dom(&self, website_url: &str) -> Result<Vec<Repo>, Box<dyn std::error::Error>>  {
+        let launch_options= LaunchOptionsBuilder::default()
+            .headless(true)  // Enable browser window
+            .build()
+            .expect("Failed to create browser instance");
+    
+        let browser = Browser::new(launch_options)?;
+        let tab = browser.new_tab()?;
+        tab.navigate_to(website_url).unwrap();
+    
+        // Wait until navigation is completed
+        tab.wait_until_navigated()?;
+    
+        // Wait for page load completion
+        tab.wait_for_element("body").unwrap();
+        let remote_object = tab
+            .evaluate("document.documentElement.outerHTML", false)
+            .ok().unwrap();
+    
+        let json = remote_object.value.unwrap();
+        let html = json.as_str();
+    
+        let document = Html::parse_document(html.unwrap());
+        let selector = Selector::parse("a").unwrap();
+    
+        let mut repos: Vec<Repo> = Vec::new();
+    
+        for element in document.select(&selector) {
+            if let Some(link) = element.value().attr("href") {
+                if link.contains("github.com") && link != "https://github.com/code-423n4/" && link != "https://github.com/code-423n4/media-kit" {
+                    log::info!("Found github link {}", link);
+                    let url = link.to_string();
+                    let name = format!("repos/{}", get_last_path_part(&url.as_str()).unwrap());
+                    let repo = Repo { url, name };
+                    repos.push(repo);
+                }
+            }
+        }
+        Ok(repos)
+    }
+}
+
+fn get_last_path_part(url: &str) -> Option<String> {
+    if let Ok(parsed_url) = Url::parse(url) {
+        parsed_url.path_segments()?.last().map(String::from)
+    } else {
+        None
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
-use crate::html_parsing;
+use crate::html_parsing::{WebsiteParser};
+use crate::c4parser::{Code4renaParser};
 use crate::github_api;
 use crate::contract::{process_repository, process_out_directory, ContractKind};
 use clap::Parser;
@@ -27,10 +28,12 @@ impl Cli {
         let args = Args::parse();
         let website_url = &args.website;
 
+        let c4parser = Code4renaParser{};
+
         // Add some information logging 
         log::info!("Parsing website {}", website_url);
         // Parse the dom, clone the repo, process the repo, print the results
-        match html_parsing::parse_dom(website_url) {
+        match c4parser.parse_dom(website_url) {
             Ok(repos) => {
                 for repo in repos {
                     match github_api::clone_repository(&repo.url, &repo.name) {

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -1,4 +1,3 @@
-use git2::Repository;
 use log;
 use std::fs;
 

--- a/src/html_parsing.rs
+++ b/src/html_parsing.rs
@@ -1,59 +1,8 @@
-//use reqwest::blocking::get;
-use headless_chrome::{Browser, LaunchOptionsBuilder};
-use log;
-use scraper::{Html, Selector};
-use url::Url;
-
 pub struct Repo {
     pub url: String,
     pub name: String
 }
 
-pub fn parse_dom(website_url: &str) -> Result<Vec<Repo>, Box<dyn std::error::Error>>  {
-    let launch_options= LaunchOptionsBuilder::default()
-        .headless(true)  // Enable browser window
-        .build()
-        .expect("Failed to create browser instance");
-
-    let browser = Browser::new(launch_options)?;
-    let tab = browser.new_tab()?;
-    tab.navigate_to(website_url);
-
-    // Wait until navigation is completed
-    tab.wait_until_navigated()?;
-
-    // Wait for page load completion
-    tab.wait_for_element("body");
-    let remote_object = tab
-        .evaluate("document.documentElement.outerHTML", false)
-        .ok().unwrap();
-
-    let json = remote_object.value.unwrap();
-    let html = json.as_str();
-
-    let document = Html::parse_document(html.unwrap());
-    let selector = Selector::parse("a").unwrap();
-
-    let mut repos: Vec<Repo> = Vec::new();
-
-    for element in document.select(&selector) {
-        if let Some(link) = element.value().attr("href") {
-            if link.contains("github.com") && link != "https://github.com/code-423n4/" && link != "https://github.com/code-423n4/media-kit" {
-                log::info!("Found github link {}", link);
-                let url = link.to_string();
-                let name = format!("repos/{}", get_last_path_part(&url.as_str()).unwrap());
-                let repo = Repo { url, name };
-                repos.push(repo);
-            }
-        }
-    }
-    Ok(repos)
-}
-
-fn get_last_path_part(url: &str) -> Option<String> {
-    if let Ok(parsed_url) = Url::parse(url) {
-        parsed_url.path_segments()?.last().map(String::from)
-    } else {
-        None
-    }
+pub trait WebsiteParser {
+    fn parse_dom(&self, website_url: &str) -> Result<Vec<Repo>, Box<dyn std::error::Error>>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod html_parsing;
 mod github_api;
 mod contract;
 mod cli;
+mod c4parser;
 
 use cli::Cli;
 use env_logger;


### PR DESCRIPTION
Breaking c4 out as a specific parser so I can have per website parsing logic for other contest sites. Not sure I am happy with the naming at the moment e.g. `parse_dom` but I will dwell on it and solve it in the future. Now I can add additional parsers and test them separately once I add command line switches to `cli.rs`.