### PR TITLE
Added Hardhat builder

### DIFF
--- a/src/builders/forge.rs
+++ b/src/builders/forge.rs
@@ -56,7 +56,7 @@ pub struct Output {
 #[serde(rename_all = "camelCase")]
 pub struct Bytecode {
     pub object: String,
-    pub source_map: String,
+    pub source_map: Option<String>,
     pub link_references: LinkReferences,
 }
 
@@ -118,7 +118,7 @@ pub struct Foreign {
     pub id: i64,
     pub name: String,
     pub node_type: String,
-    pub referenced_declaration: i64,
+    pub referenced_declaration: Option<i64>,
     pub src: String,
 } 
 pub struct ForgeBuilder;
@@ -178,7 +178,7 @@ impl Build for ForgeBuilder {
 
 pub fn process_out_directory(repo_directory: &str) -> (String, Vec<Contract>) {
     let out_dir = Path::new(&repo_directory).join("out");
-    log::info!("Looking for build contracts in {}", &out_dir.to_string_lossy());
+    log::info!("Looking for built contracts in {}", &out_dir.to_string_lossy());
 
     // Contract map stores a mapping from contract name to Contract.
     let mut contract_map: HashMap<String, Contract> = HashMap::new();

--- a/src/builders/hardhat.rs
+++ b/src/builders/hardhat.rs
@@ -1,11 +1,262 @@
+use std::process::{Command, exit};
+use log;
+use std::path::{Path};
+use std::fs;
+use std::env;
+use std::collections::HashMap;
+use walkdir::WalkDir;
+
 use crate::builders::build::Build;
-use crate::contract::Contract;
+use crate::contract::{Contract, ContractKind};
 
-pub struct HardhatBuilder;
-/*
-impl Build for HardhatBuilder {
-    fn build(&self, directory: &str) -> Result<(String, Vec<Contract>), Box<dyn std::error::Error>> {
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
+    #[serde(rename = "_format")]
+    pub format: String,
+    pub contract_name: String,
+    pub source_name: String,
+    pub abi: Vec<Abi>,
+    pub bytecode: String,
+    pub deployed_bytecode: String,
+    pub link_references: serde_json::Value,
+    pub deployed_link_references: DeployedLinkReferences,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Abi {
+    pub inputs: Option<Vec<Input>>,
+    pub state_mutability: Option<String>,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub anonymous: Option<bool>,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub outputs: Vec<Output>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Input {
+    pub indexed: Option<bool>,
+    pub internal_type: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Output {
+    pub internal_type: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkReferences {
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployedLinkReferences {
+}
+
+#[derive(Debug)]
+pub enum HardhatMode {
+    Yarn,
+    Npm,
+}
+
+pub struct HardhatBuilder {
+    pub mode: HardhatMode,
+}
+
+impl HardhatBuilder {
+    pub fn new(mode: HardhatMode) -> Self {
+        Self { mode }
+    }
+
+    pub fn set_mode(&mut self, mode: HardhatMode) {
+        self.mode = mode;
+    }
+
+    pub fn flip_mode(&mut self) {
+        match self.mode {
+            HardhatMode::Yarn => self.mode = HardhatMode::Npm,
+            HardhatMode::Npm => self.mode = HardhatMode::Yarn,
+        }
     }
 }
-*/
+
+impl Build for HardhatBuilder {
+    fn build(&self, directory: &str) -> Result<(String, Vec<Contract>), Box<dyn std::error::Error>> {
+        let (install_cmd, install_arg, compile_cmd, compile_arg) = match self.mode {
+            HardhatMode::Yarn => ("yarn", "", "yarn", "compile"),
+            HardhatMode::Npm => ("npm", "install", "npx", "hardhat compile"),
+        };
+
+        log::info!("Executing {} in {}", install_cmd, directory);
+        let install_result = Command::new(install_cmd)
+            .arg(install_arg)
+            .current_dir(directory)
+            .output();
+    
+        if let Err(err) = install_result {
+            eprintln!("Error executing '{}' with '{}': {}", install_cmd, install_arg, err);
+            exit(1);
+        }
+    
+        // Execute `forge build` in the repository directory
+        log::info!("Executing {} compile in {}", compile_cmd, directory);
+        let build_result = Command::new(compile_cmd)
+            .arg(compile_arg)
+            .current_dir(directory)
+            .output();
+    
+        if let Err(err) = build_result {
+            eprintln!("Error executing '{}' with '{}': {}", compile_cmd, compile_arg, err);
+            exit(1);
+        }
+
+        let cache_dir = Path::new(&directory).join("cache");
+        if !cache_dir.exists() || !cache_dir.is_dir() {
+            eprintln!("Error: 'cache' directory not found in {}", directory);
+            //exit(1);
+        }
+        
+        let artifacts_dir = Path::new(&directory).join("artifacts");
+        log::info!("Checking for the artifacts directory {}", artifacts_dir.to_string_lossy());
+        if !artifacts_dir.exists() {
+            eprintln!("Error: 'artifacts' directory {} not found in {}", artifacts_dir.to_string_lossy(), directory);
+            //exit(1);
+        }
+
+        let result = process_artifacts_directory(directory);
+        Ok(result)
+    }
+}
+
+pub fn process_artifacts_directory(repo_directory: &str) -> (String, Vec<Contract>) {
+    let out_dir = Path::new(&repo_directory).join("artifacts");
+    log::info!("Looking for built contracts in {}", &out_dir.to_string_lossy());
+
+    // Contract map stores a mapping from contract name to Contract.
+    let mut contract_map: HashMap<String, Contract> = HashMap::new();
+
+    let walker = WalkDir::new(&out_dir).into_iter();
+
+    // First pass will find all json files, parse them and add them to a contract_map
+    // Imports are None at this stage as they are populated in the second pass. 
+
+    for entry in walker.flatten() {
+        let entry_path = entry.path();
+
+        if entry_path.is_file() {
+            if let Some(extension) = entry_path.extension() {
+                if extension == "json" {
+                    if let Some(file_stem) = entry_path.file_stem() {
+                        if let Some(contract_name) = file_stem.to_str() {
+                            if !contract_name.ends_with(".dbg") { // Hardhat will add .dbg.json to some files. Ignoring those.
+                                let json_content = match fs::read_to_string(&entry_path) {
+                                    Ok(content) => content,
+                                    Err(err) => {
+                                        eprintln!("Error reading JSON file '{}': {}", entry_path.display(), err);
+                                        continue;
+                                    }
+                                };
+
+                                let metadata: Metadata = match serde_json::from_str(&json_content) {
+                                    Ok(metadata) => metadata,
+                                    Err(err) => {
+                                        eprintln!("Error parsing JSON file '{}': {}", entry_path.display(), err);
+                                        continue;
+                                    }
+                                };
+
+                                let bytecode_object = metadata.bytecode;
+
+                                let contract_kind = if bytecode_object == "0x" {
+                                    ContractKind::Interface
+                                } else {
+                                    ContractKind::Contract
+                                };
+
+                                let contract = Contract {
+                                    contract_name: contract_name.to_owned(),
+                                    contract_kind,
+                                    bytecode: bytecode_object.to_owned(),
+                                    imports: None,
+                                };
+                                contract_map.insert(contract_name.to_owned(), contract);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // In the second pass we read the json file, parse the imports.
+    // Then look for the contract in the hashmap and if it's there 
+    // We append the imports to the contract's imports field.
+
+    let contract_map_clone = contract_map.clone();
+
+    let walker = WalkDir::new(&out_dir).into_iter();
+
+    for entry in walker.flatten() {
+        let entry_path = entry.path();
+
+        if entry_path.is_file() && entry_path.extension() == Some("json".as_ref()) {
+            if let Some(file_stem) = entry_path.file_stem() {
+                if let Some(contract_name) = file_stem.to_str() {
+                    if !contract_name.ends_with(".dbg") { // Hardhat will add .dbg.json to some files. Ignoring those.
+                        let json_content = match fs::read_to_string(&entry_path) {
+                            Ok(content) => content,
+                            Err(err) => {
+                                eprintln!("Error reading JSON file '{}': {}", entry_path.display(), err);
+                                continue;
+                            }
+                        };
+
+                        let metadata: Metadata = match serde_json::from_str(&json_content) {
+                            Ok(metadata) => metadata,
+                            Err(parseerr) => {
+                                eprintln!("Error parsing JSON file '{}': {}", entry_path.display(), parseerr);
+                                continue;
+                            }
+                        };
+                        println!("Link References: {:?}", metadata.link_references);
+                        /*
+                        if let Some(contract) = contract_map.get_mut(contract_name) {
+                            for node in metadata.ast.nodes {
+                                if node.node_type == "ImportDirective" {
+                                    for symbol_alias in node.symbol_aliases {
+                                        let foreign_name = symbol_alias.foreign.name.clone();
+
+                                        if let Some(imported_contract) = contract_map_clone.get(&foreign_name) {
+                                            contract.imports.get_or_insert_with(Vec::new).push(imported_contract.clone());
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            eprintln!("Error retrieving contract from HashMap");
+                        }
+                        */
+                    }
+                }
+            }
+        }
+    }
+    // contract_map should have all contracts with all imports
+    let contracts: Vec<Contract> = contract_map.values().cloned().collect();
+    (repo_directory.to_owned(), contracts)
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,7 +1,9 @@
 use log;
 use std::path::{Path};
+use walkdir::WalkDir;
 use crate::builders::build::Build;
 use crate::builders::forge::ForgeBuilder;
+use crate::builders::hardhat::{HardhatBuilder, HardhatMode};
 
 // Contract struct. ContractKind for Contract vs Interfaces. Interfaces have the bytecode 0x
 #[derive(Clone, Debug)]
@@ -18,11 +20,43 @@ pub enum ContractKind {
 }
 
 pub fn process_repository(repo_directory: &str) -> Result<(String, Vec<Contract>), Box<dyn std::error::Error>> {
-    let foundry_file = Path::new(repo_directory).join("foundry.toml");
-    if !foundry_file.exists() {
-        return Err("Error: 'foundry.toml' not found in the repository directory".into());
-    }
+    for entry in WalkDir::new(repo_directory).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_dir() {
+            let subdir = entry.path();
+            let hardhat_config_ts = subdir.join("hardhat.config.ts");
+            let hardhat_config_js = subdir.join("hardhat.config.js");
 
-    let builder = ForgeBuilder;
-    builder.build(repo_directory)
+            if hardhat_config_ts.exists() || hardhat_config_js.exists() {
+                let mut builder = HardhatBuilder::new(HardhatMode::Npm);
+
+                if subdir.join("yarn.lock").exists() {
+                    log::info!("Setting HardhatBuilder to Yarn mode");
+                    builder.set_mode(HardhatMode::Yarn);
+                }
+
+                let (directory, contracts) = builder.build(subdir.to_str().unwrap())?;
+                if contracts.is_empty() {
+                    builder.flip_mode(); // Whatever mode you were that didn't work, try the other.
+                    log::info!("No contracts found, trying HardhatBuilder in {:?} mode", builder.mode);
+                    let (directory, contracts) = builder.build(subdir.to_str().unwrap())?;
+                    if contracts.is_empty() {
+                        log::info!("No contracts found, trying FoundryBuilder");
+                        let foundry_builder = ForgeBuilder;
+                        return foundry_builder.build(subdir.to_str().unwrap());
+                    } else {
+                        return Ok((directory, contracts));
+                    }
+                } else {
+                    return Ok((directory, contracts));
+                }
+            } else {
+                let foundry_file = subdir.join("foundry.toml");
+                if foundry_file.exists() {
+                    let builder = ForgeBuilder;
+                    return builder.build(subdir.to_str().unwrap())
+                }
+            }
+        }
+    }
+    Ok(("".to_string(), Vec::new()))
 }

--- a/src/parsers/code4rena.rs
+++ b/src/parsers/code4rena.rs
@@ -48,7 +48,7 @@ impl WebsiteParser for Code4renaParser {
         for element in document.select(&selector) {
             if let Some(link) = element.value().attr("href") {
                 if link.contains("github.com") && link != "https://github.com/code-423n4/" && link != "https://github.com/code-423n4/media-kit" {
-                    log::info!("Found github link {}", link);
+                    log::debug!("Found github link {}", link);
                     let url = link.to_string();
                     let name = format!("repos/{}", get_last_path_part(&url.as_str()).unwrap());
                     let commit = None;

--- a/src/parsers/sherlock.rs
+++ b/src/parsers/sherlock.rs
@@ -98,7 +98,7 @@ impl WebsiteParser for SherlockParser {
                                 if link.contains("github.com") {
                                     // Parse the github url for repo and commit
                                     if let Some((url, repo, sha)) = github_api::parse_github_url(link) {
-                                        log::info!("Found github link {}. Cloning {} with sha {}", url, repo, sha);
+                                        log::debug!("Found github link {}. Cloning {} with sha {}", url, repo, sha);
                                         let name = format!("repos/{}", repo);
                                         let commit = Some(sha);
                                         let repo = Repo { url, name, commit};


### PR DESCRIPTION
Hardhat builder will try and determine the type of project (Yarn or NPM) and build the project. If it fails using one it will use the other. If it fails building using both it will try foundry.

Currently the HardhatBuilder returns byte code for contracts but doesn't map the imports for each contract.