### PR TITLE
Async parsers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 clap = { version = "4.3.4", features = ["derive"] }
 log = "0.4.19"
 env_logger = "0.10.0"
-reqwest = { version = "0.11.18", features = ["blocking", "json"]}
+reqwest = { version = "0.11.18", features = ["json"]}
 git2 = "0.17.2"
 headless_chrome = "1.0.5"
 scraper = "0.16.0"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Test with;
 
 `RUST_LOG=info cargo run -- -t`
 
-If you want to by-pass the Website Parsers and just test a repository. e.g.;
+If you want to bypass the Website Parsers and just test a repository. e.g.;
 
 `RUST_LOG=debug cargo run -- -t -g https://github.com/smartcontractkit/truffle-starter-kit`
+
+Get command line arguments with
+
+`RUST_LOG=info cargo run -- -t`
+
+Set a larger builder pool with `-m`
+
+`RUST_LOG=info cargo run -- -t -m 30`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,7 +57,6 @@ impl Cli {
                     immunefi.parse_dom().await
                 }
             }));
-            /*
             
             tasks.push(spawn({
                 let code4rena = Arc::new(Code4renaParser::new());
@@ -80,8 +79,6 @@ impl Cli {
                 }
             }));
 
-            */
-            
             let results: Vec<Result<_, Box<dyn std::error::Error + std::marker::Send + Sync>>> = try_join_all(tasks)
                 .await.unwrap();
             println!("{:?}", results);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,8 @@ impl Cli {
                     sherlock.parse_dom().await
                 }
             }));
+
+            /*
             
             tasks.push(spawn({
                 let code4rena = Arc::new(Code4renaParser::new());
@@ -78,6 +80,7 @@ impl Cli {
                     immunefi.parse_dom().await
                 }
             }));
+            */
             
             let results: Vec<Result<_, Box<dyn std::error::Error + std::marker::Send + Sync>>> = try_join_all(tasks)
                 .await.unwrap();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,33 +51,29 @@ impl Cli {
                 }
             });
         } else {
-            let sherlock = Arc::new(SherlockParser::new());
             tasks.push(spawn({
-                let sherlock = Arc::clone(&sherlock);
+                let sherlock = Arc::new(SherlockParser::new());
                 async move {
                     sherlock.parse_dom().await
                 }
             }));
-
-            let code4rena = Arc::new(Code4renaParser::new());
+            
             tasks.push(spawn({
-                let code4rena = Arc::clone(&code4rena);
+                let code4rena = Arc::new(Code4renaParser::new());
                 async move {
                     code4rena.parse_dom().await
                 }
             }));
 
-            let hats = Arc::new(HatsParser::new());
             tasks.push(spawn({
-                let hats = Arc::clone(&hats);
+                let hats = Arc::new(HatsParser::new());
                 async move {
                     hats.parse_dom().await
                 }
             }));
 
-            let immunefi = Arc::new(ImmunefiParser::new());
             tasks.push(spawn({
-                let immunefi = Arc::clone(&immunefi);
+                let immunefi = Arc::new(ImmunefiParser::new());
                 async move {
                     immunefi.parse_dom().await
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,9 +52,9 @@ impl Cli {
             });
         } else {
             tasks.push(spawn({
-                let sherlock = Arc::new(SherlockParser::new());
+                let hats = Arc::new(HatsParser::new());
                 async move {
-                    sherlock.parse_dom().await
+                    hats.parse_dom().await
                 }
             }));
 
@@ -68,9 +68,9 @@ impl Cli {
             }));
 
             tasks.push(spawn({
-                let hats = Arc::new(HatsParser::new());
+                let sherlock = Arc::new(SherlockParser::new());
                 async move {
-                    hats.parse_dom().await
+                    sherlock.parse_dom().await
                 }
             }));
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,9 @@ struct Args {
 
     #[arg(short, long)]
     github: Option<String>,
+
+    #[arg(short, long, default_value = "10")]
+    max_builders: usize,
 }
 
 pub struct Cli {
@@ -79,8 +82,8 @@ impl Cli {
                 }
             }));
 
-            let max_concurrent_builders = 10; // Set the maximum number of concurrent builders.
-            let semaphore = Arc::new(Semaphore::new(max_concurrent_builders));
+            //let max_concurrent_builders = 10; // Set the maximum number of concurrent builders.
+            let semaphore = Arc::new(Semaphore::new(args.max_builders));
             
             let builder_tasks = try_join_all(tasks)
                 .await

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,12 +52,11 @@ impl Cli {
             });
         } else {
             tasks.push(spawn({
-                let hats = Arc::new(HatsParser::new());
+                let immunefi = Arc::new(ImmunefiParser::new());
                 async move {
-                    hats.parse_dom().await
+                    immunefi.parse_dom().await
                 }
             }));
-
             /*
             
             tasks.push(spawn({
@@ -75,11 +74,12 @@ impl Cli {
             }));
 
             tasks.push(spawn({
-                let immunefi = Arc::new(ImmunefiParser::new());
+                let hats = Arc::new(HatsParser::new());
                 async move {
-                    immunefi.parse_dom().await
+                    hats.parse_dom().await
                 }
             }));
+
             */
             
             let results: Vec<Result<_, Box<dyn std::error::Error + std::marker::Send + Sync>>> = try_join_all(tasks)

--- a/src/parsers/code4rena.rs
+++ b/src/parsers/code4rena.rs
@@ -1,8 +1,7 @@
 use headless_chrome::{Browser, LaunchOptionsBuilder};
 use log;
 use scraper::{Html, Selector};
-
-use crate::parsers::parse::{WebsiteParser, Repo};
+use crate::parsers::parse::Repo;
 use crate::github_api;
 
 pub struct Code4renaParser {
@@ -17,8 +16,8 @@ impl Code4renaParser {
     }
 }
 
-impl WebsiteParser for Code4renaParser {
-    fn parse_dom(&self) -> Result<Vec<Repo>, Box<dyn std::error::Error>>  {
+impl Code4renaParser {
+    pub async fn parse_dom(&self) -> Result<Vec<Repo>, Box<dyn std::error::Error + Send + Sync>>  {
         let launch_options= LaunchOptionsBuilder::default()
             .headless(true)  // Enable browser window
             .build()

--- a/src/parsers/hats.rs
+++ b/src/parsers/hats.rs
@@ -58,7 +58,8 @@ pub struct MyQuery;
 pub struct HatsParser {
     pub urls: Vec<String>,
 }
-
+// Hats has a graphql API for each chain that returns a series of IPFS hashes.
+// These IPFS hashes are json that can be parsed concurrently.
 impl HatsParser {
     pub fn new() -> Self {
         HatsParser {
@@ -75,7 +76,7 @@ impl HatsParser {
         let mut repos: Vec<Repo> = Vec::new();
 
         // Construct the GraphQL query
-        let variables: my_query::Variables = my_query::Variables {}; // Define your variables here
+        let variables: my_query::Variables = my_query::Variables {}; // Variables are empty. 
         let query = MyQuery::build_query(variables);
 
         // Create a Reqwest client
@@ -84,10 +85,13 @@ impl HatsParser {
         // Construct the GraphQL request body
         let body = json!({
             "query": query.query.to_string(),
+            // variables would go here if required.
         });
 
+        // A description block of text could contain multiple github links. We want a unique set. 
         let mut unique_github_links: HashSet<String> = HashSet::new();
-        
+
+        // For each chain we want to query the Hats Graphql Api. 
         for url in &self.urls {
             log::info!("Querying {}", url);
             // Send the GraphQL request
@@ -96,7 +100,8 @@ impl HatsParser {
                 .header("Content-Type", "application/json")
                 .json(&body)
                 .send().await?;
-
+            
+            // The IPFS hashes are returned in the query response.
             let response_body: Response<my_query::ResponseData> = response.json().await?;
             let base_url = "https://ipfs.io/ipfs";
 
@@ -154,7 +159,7 @@ impl HatsParser {
                 }
             }
         }
-
+        // Similar to other parsers, create repo structs and return a Vec of them
         for github_link in unique_github_links {
             let url = github_link.to_string();
             let name = format!("repos/{}", github_api::get_last_path_part(&url.as_str()).unwrap());

--- a/src/parsers/immunefi.rs
+++ b/src/parsers/immunefi.rs
@@ -27,12 +27,13 @@ impl ImmunefiParser {
         let mut unique_github_links: HashSet<String> = HashSet::new();
         let url = self.url.clone(); 
 
+        // Chrome needs to be run in blocking mode.
         let unique_links = spawn_blocking(move || {
             let inner_selector = Selector::parse("a").unwrap();
             let mut unique_bounty_links: HashSet<String> = HashSet::new();
 
             let launch_options= LaunchOptionsBuilder::default()
-            .headless(true)  // Enable browser window
+            .headless(true)  // Enable browser window if you need to test visually.
             .build()
             .expect("Failed to create browser instance");
     
@@ -42,9 +43,9 @@ impl ImmunefiParser {
             tab.navigate_to(&url).unwrap();
         
             // Wait until navigation is completed
-            tab.wait_until_navigated();
+            tab.wait_until_navigated().unwrap();
         
-            // Wait for page load completion
+            // Wait for page load completion and grab the entire HTML.
             tab.wait_for_element("body").unwrap();
             let remote_object = tab
                 .evaluate("document.documentElement.outerHTML", false)
@@ -57,6 +58,7 @@ impl ImmunefiParser {
 
             for element in document.select(&inner_selector) {
                 if let Some(link) = element.value().attr("href") {
+                    // All immunefi bounty urls contain the word bounty
                     if link.contains("bounty") {
                         log::debug!("Found immunefi bounty link {}", link);
                         unique_bounty_links.insert(link.to_owned());
@@ -66,18 +68,18 @@ impl ImmunefiParser {
             unique_bounty_links
         }).await.unwrap();
 
-        // For each bounty URL navigate to it and see if there's anyt github links in there.
+        // For each bounty URL navigate to it and see if there's any github links in the page. 
         let base_url = "https://immunefi.com";
         let mut tasks = Vec::new();
 
-        // Rate-limiting variables
+        // Rate-limiting variables. Add max sessions to a semaphore so we don't overly hammer Immunefi.
         let max_concurrent_requests = 30; // Set the maximum number of concurrent requests
         let semaphore = Arc::new(Semaphore::new(max_concurrent_requests));
 
         for bounty_url in unique_links.into_iter().collect::<Vec<String>>() {
             let semaphore = Arc::clone(&semaphore); 
 
-            // Spawn a task for each bounty URL
+            // Spawn a task for each bounty. These run concurrently but all results are collected together. 
             let task = spawn(async move {
                 let permit = semaphore.acquire().await.expect("Failed to acquire semaphore permit"); 
                 let selector = Selector::parse("a").unwrap();
@@ -93,7 +95,6 @@ impl ImmunefiParser {
                 for element in document.select(&selector) {
                     if let Some(link) = element.value().attr("href") {
                         if link.contains("github.com") && !link.contains("immunefi-team") {
-                            log::debug!("Found github url {}", link);
                             // Parse for the github repo format
                             let parsed_url = Url::parse(&link);
                             if let Ok(url) = parsed_url {
@@ -101,6 +102,7 @@ impl ImmunefiParser {
                                 let formatted_path = path_segments.take(2).collect::<Vec<_>>().join("/");
                                 let formatted_url = format!("{}://{}/{}", url.scheme(), url.host_str().unwrap(), formatted_path);
                                 github_links.insert(formatted_url.to_owned());
+                                log::debug!("Found github url {}", link);
                             } else {
                                 log::error!("Couldn't parse the url {}", link)
                             }
@@ -113,7 +115,7 @@ impl ImmunefiParser {
             tasks.push(task);
         }
 
-        // Wait for all tasks to complete concurrently
+        // Wait for all tasks to complete (concurrently).
         let results = futures::future::try_join_all(tasks).await?;
         
         // Iterate over the results and collect the unique GitHub links
@@ -121,7 +123,8 @@ impl ImmunefiParser {
             let github_links = result?;
             unique_github_links.extend(github_links);
         }
-
+        
+        // Turn the results into repos
         for github_link in unique_github_links {
             let url = github_link.to_string();
             let name = format!("repos/{}", github_api::get_last_path_part(&url.as_str()).unwrap());

--- a/src/parsers/immunefi.rs
+++ b/src/parsers/immunefi.rs
@@ -82,7 +82,7 @@ impl ImmunefiParser {
                 let permit = semaphore.acquire().await.expect("Failed to acquire semaphore permit"); 
                 let selector = Selector::parse("a").unwrap();
                 let full_url = format!("{}{}", base_url, bounty_url);
-                log::info!("Parsing url {}", full_url);
+                log::debug!("Parsing url {}", full_url);
 
                 let response = reqwest::get(&full_url).await?;
                 let body = response.text().await?;

--- a/src/parsers/immunefi.rs
+++ b/src/parsers/immunefi.rs
@@ -7,6 +7,9 @@ use crate::github_api;
 use crate::parsers::parse::Repo;
 use tokio::task::{spawn_blocking, spawn};
 use tokio::time::Duration;
+use tokio::time::Instant;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 pub struct ImmunefiParser {
     pub url: String,
@@ -67,35 +70,58 @@ impl ImmunefiParser {
 
         // For each bounty URL navigate to it and see if there's anyt github links in there.
         let base_url = "https://immunefi.com";
-        let selector = Selector::parse("a").unwrap();
+        let mut tasks = Vec::new();
+
+        // Rate-limiting variables
+        let max_concurrent_requests = 30; // Set the maximum number of concurrent requests
+        let semaphore = Arc::new(Semaphore::new(max_concurrent_requests));
 
         for bounty_url in unique_links.into_iter().collect::<Vec<String>>() {
-            let full_url = format!("{}{}", base_url, bounty_url);
-            log::info!("Parsing url {}", full_url);
+            let semaphore = Arc::clone(&semaphore); 
 
-            let response = reqwest::get(&full_url).await?;
-            let body = response.text().await?;
-            let document = Html::parse_document(&body);
+            // Spawn a task for each bounty URL
+            let task = tokio::spawn(async move {
+                let permit = semaphore.acquire().await.expect("Failed to acquire semaphore permit"); 
+                let selector = Selector::parse("a").unwrap();
+                let full_url = format!("{}{}", base_url, bounty_url);
+                log::info!("Parsing url {}", full_url);
 
-            for element in document.select(&selector) {
-                if let Some(link) = element.value().attr("href") {
-                    if link.contains("github.com") && !link.contains("immunefi-team") {
-                        // Parse for the github repo format
-                        let parsed_url = Url::parse(&link);
-                        if let Ok(url) = parsed_url {
-                            let path_segments = url.path_segments().unwrap();
-                            let formatted_path = path_segments.take(2).collect::<Vec<_>>().join("/");
-                            let formatted_url = format!("{}://{}/{}", url.scheme(), url.host_str().unwrap(), formatted_path);
-                            if unique_github_links.insert(formatted_url.to_owned()) {
-                                // Only logging on new github urls
-                                log::info!("Found github link: {}", formatted_url);
+                let response = reqwest::get(&full_url).await?;
+                let body = response.text().await?;
+                let document = Html::parse_document(&body);
+
+                let mut github_links = HashSet::new();
+
+                for element in document.select(&selector) {
+                    if let Some(link) = element.value().attr("href") {
+                        if link.contains("github.com") && !link.contains("immunefi-team") {
+                            log::debug!("Found github url {}", link);
+                            // Parse for the github repo format
+                            let parsed_url = Url::parse(&link);
+                            if let Ok(url) = parsed_url {
+                                let path_segments = url.path_segments().unwrap();
+                                let formatted_path = path_segments.take(2).collect::<Vec<_>>().join("/");
+                                let formatted_url = format!("{}://{}/{}", url.scheme(), url.host_str().unwrap(), formatted_path);
+                                github_links.insert(formatted_url.to_owned());
+                            } else {
+                                log::error!("Couldn't parse the url {}", link)
                             }
-                        } else {
-                            log::error!("Couldn't parse the url {}", link)
                         }
                     }
                 }
-            }
+                drop(permit);
+                Ok::<HashSet<String>, Box<dyn std::error::Error + Send + Sync>>(github_links)
+            });
+            tasks.push(task);
+        }
+
+        // Wait for all tasks to complete concurrently
+        let results = futures::future::try_join_all(tasks).await?;
+        
+        // Iterate over the results and collect the unique GitHub links
+        for result in results {
+            let github_links = result?;
+            unique_github_links.extend(github_links);
         }
 
         for github_link in unique_github_links {

--- a/src/parsers/immunefi.rs
+++ b/src/parsers/immunefi.rs
@@ -4,8 +4,7 @@ use scraper::{Html, Selector};
 use url::Url;
 use std::collections::HashSet;
 use crate::github_api;
-
-use crate::parsers::parse::{WebsiteParser, Repo};
+use crate::parsers::parse::Repo;
 
 pub struct ImmunefiParser {
     pub url: String,
@@ -19,8 +18,8 @@ impl ImmunefiParser {
     }
 }
 
-impl WebsiteParser for ImmunefiParser {
-    fn parse_dom(&self) -> Result<Vec<Repo>, Box<dyn std::error::Error>>  {
+impl ImmunefiParser {
+    pub async fn parse_dom(&self) -> Result<Vec<Repo>, Box<dyn std::error::Error + Send + Sync>> {
         let launch_options= LaunchOptionsBuilder::default()
             .headless(true)  // Enable browser window
             .build()

--- a/src/parsers/immunefi.rs
+++ b/src/parsers/immunefi.rs
@@ -6,8 +6,6 @@ use std::collections::HashSet;
 use crate::github_api;
 use crate::parsers::parse::Repo;
 use tokio::task::{spawn_blocking, spawn};
-use tokio::time::Duration;
-use tokio::time::Instant;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
@@ -80,7 +78,7 @@ impl ImmunefiParser {
             let semaphore = Arc::clone(&semaphore); 
 
             // Spawn a task for each bounty URL
-            let task = tokio::spawn(async move {
+            let task = spawn(async move {
                 let permit = semaphore.acquire().await.expect("Failed to acquire semaphore permit"); 
                 let selector = Selector::parse("a").unwrap();
                 let full_url = format!("{}{}", base_url, bounty_url);

--- a/src/parsers/parse.rs
+++ b/src/parsers/parse.rs
@@ -1,3 +1,6 @@
+use std::error::Error;
+use std::fmt;
+
 #[derive(Debug)]
 pub struct Repo {
     pub url: String,
@@ -5,7 +8,23 @@ pub struct Repo {
     pub commit: Option<String>,
 }
 
-pub trait WebsiteParser {
-    fn parse_dom(&self) -> Result<Vec<Repo>, Box<dyn std::error::Error>>;
-    fn url(&self) -> &str;
+#[derive(Debug)]
+pub struct ParseError {
+    message: String,
+}
+
+impl ParseError {
+    pub fn new(message: &str) -> Self {
+        ParseError {
+            message: message.to_string(),
+        }
+    }
+}
+
+impl Error for ParseError {}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
 }

--- a/src/parsers/sherlock.rs
+++ b/src/parsers/sherlock.rs
@@ -73,7 +73,8 @@ pub struct Contest {
     #[serde(rename = "description")]
     pub description: String,
 }
-
+// Sherlock has an API that you can query to get a list of contests and their current state.
+// For the running contests we get their ids and then query and parse their web pages.
 impl SherlockParser {
     pub async fn parse_dom(&self)  -> Result<Vec<Repo>, Box<dyn Error + Send + Sync>>  {
         let mut repos: Vec<Repo> = Vec::new();
@@ -84,11 +85,12 @@ impl SherlockParser {
             let contests: Root = serde_json::from_str(&json_string)?;
 
             let mut tasks = Vec::new();
-
+            // Only look for RUNNING contests.
             for contest in contests {
                 if contest.status == "RUNNING" {
                     let contest_url = format!("{}/{}", self.url, contest.id);
                     log::debug!("Spawning to retrieve {}", contest_url);
+                    // Parse contests concurrently.
                     let task = task::spawn(parse_contest(contest_url));
                     tasks.push(task);
                 }


### PR DESCRIPTION
Removed all blocking dependencies (e.g. reqwest blocking) and made all parsers concurrent. `spawn_blocking` is still required as some libraries like head_less chrome do not support async. Immunefi has a lot of bounty urls so it's rate limited using a semaphore. Similarly when all repos are returned a builder pool builds the projects. This is set to 10 by default but is configurable via a command line option `-m`.